### PR TITLE
Fix ConGameSpeed checking for no args

### DIFF
--- a/src/citymania/cm_console_cmds.cpp
+++ b/src/citymania/cm_console_cmds.cpp
@@ -47,7 +47,7 @@ void IConsoleError(fmt::format_string<Args...> format, Args&&... args) {
 }
 
 bool ConGameSpeed(std::span<std::string_view> argv) {
-    if (argv.empty() == 0 || argv.size() > 2) {
+    if (argv.empty() || argv.size() > 2) {
         IConsoleHelp("Changes game speed. Usage: 'cmgamespeed [n]'");
         return true;
     }


### PR DESCRIPTION
ConGameSpeed had incorrect argument checks, was checking for `argv.empty() == 0` (i.e. there are args) instead of just `argv.empty()` (i.e. there are no args).