### PR TITLE
Codefix: dumb fixes for nullptr exception

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -429,6 +429,8 @@ RoadBits FindRailsToConnect(TileIndex tile) {
 	DiagDirection ddir;
 	for (ddir = DIAGDIR_BEGIN; ddir < DIAGDIR_END; ddir++) {
 		TileIndex cur_tile = TileAddByDiagDir(tile, ddir);
+            if (cur_tile >= Map::Size())
+                continue;
 		if (HasStationTileRail(cur_tile)) {
 			if (GetRailStationTrackBits(cur_tile) & DiagdirReachesTracks(ddir)) {
 				directed |= DiagDirToRoadBits(ddir);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1224,7 +1224,7 @@ void NWidgetCore::SetTextStyle(TextColour colour, FontSize size)
  */
 void NWidgetCore::SetToolTip(StringID tool_tip)
 {
-	this->tool_tip = tool_tip;
+	if (this) this->tool_tip = tool_tip;
 }
 
 /**


### PR DESCRIPTION
These fixes are only to make game playable so there are no crashes, haven't tried to reproduce them
